### PR TITLE
FEAT/trim fn

### DIFF
--- a/src/valid.gleam
+++ b/src/valid.gleam
@@ -287,6 +287,21 @@ pub fn string_max_length(
   }
 }
 
+/// Trim the input
+///
+/// e.g.
+/// ```gleam
+///let validator = fn(input) {
+///  use out <- valid.check(input, valid.trim("  hello   "))
+///  //   ╰──── "hello"
+///  valid.ok(out)
+///}
+/// ```
+///
+pub fn trim() -> Validator(String, String, err) {
+  fn(value: String) { #(string.trim(value), []) }
+}
+
 /// Compose two validators.
 /// This will only return the first error found.
 ///

--- a/test/valid_test.gleam
+++ b/test/valid_test.gleam
@@ -201,6 +201,29 @@ pub fn string_is_int_test() {
   |> should.equal(Error(["NaN"]))
 }
 
+pub fn string_trim_test() {
+  let validator = fn(input) {
+    use out <- valid.check(input, valid.trim())
+    valid.ok(out)
+  }
+
+  "  hello     "
+  |> valid.validate(validator)
+  |> should.equal(Ok("hello"))
+
+  "hello       "
+  |> valid.validate(validator)
+  |> should.equal(Ok("hello"))
+
+  "       hello"
+  |> valid.validate(validator)
+  |> should.equal(Ok("hello"))
+
+  "hello"
+  |> valid.validate(validator)
+  |> should.equal(Ok("hello"))
+}
+
 pub fn string_is_float_test() {
   let validator = fn(input) {
     use out <- valid.check(input, valid.string_is_float("NaN"))


### PR DESCRIPTION
This pr introduces a new trim function. It allows you to automatically remove leading and trailing whitespace from strings before validation or transformation. This is especially useful for user input where accidental spaces can lead to unexpected validation errors.

Example:

```gleam
  let validator = fn(input) {
    use out <- valid.check(input, valid.trim())
    valid.ok(out)
  }

  "  hello              "
  |> valid.validate(validator)
  |> should.equal(Ok("hello"))
```